### PR TITLE
Find MKL where it's actually installed

### DIFF
--- a/dlib/cmake_utils/cmake_find_blas.txt
+++ b/dlib/cmake_utils/cmake_find_blas.txt
@@ -68,6 +68,7 @@ if (UNIX OR MINGW)
 
     if (SIZE_OF_VOID_PTR EQUAL 8)
         set( mkl_search_path
+            ${MKLROOT}/lib/intel64
             /opt/intel/mkl/*/lib/em64t
             /opt/intel/mkl/lib/intel64
             /opt/intel/lib/intel64
@@ -77,6 +78,7 @@ if (UNIX OR MINGW)
         mark_as_advanced(mkl_intel)
     else()
         set( mkl_search_path
+            ${MKLROOT}/lib/ia32
             /opt/intel/mkl/*/lib/32
             /opt/intel/mkl/lib/ia32
             /opt/intel/lib/ia32


### PR DESCRIPTION
MKLROOT is a canonical environment variable defined by MKL's scripts. You should use it when available if you want to properly look for MKL.